### PR TITLE
CODAP-751 Revisiting bug where Markov creates a dataset when one already exists

### DIFF
--- a/Markov/js/markov_model.js
+++ b/Markov/js/markov_model.js
@@ -73,7 +73,8 @@ MarkovModel.prototype.initialize = async function()
     action: 'get',
     resource: 'dataContextList'
   });
-  if (iResult.success && !iResult.values.some(ds => ds.name === "Games/Turns")) {
+  // It can happen that an existing dataset has "Games/Turns" as either its name or title, so we check both.
+  if (iResult.success && !iResult.values.some(ds => [ds.name, ds.title].includes("Games/Turns"))) {
     await codapHelper.createDataset({
       name: "Games/Turns",
       collections: [


### PR DESCRIPTION
[#CODAP-751] Bug fix: On initialization Markov creates dataset even if present

* We are revisiting this bug fix because the first "fix" checked only the dataset's title, but the deployed example document dataset has "Games/Turns" as its name. We check both and don't create a new dataset if we find either.